### PR TITLE
Add support for SSL webhook requirement

### DIFF
--- a/node/config/default.json
+++ b/node/config/default.json
@@ -1,5 +1,8 @@
 {
     "appSecret": "",
+    "ca": "",
+    "cert": "",
+    "key": "",
     "pageAccessToken": "",
     "validationToken": "",
     "serverURL": ""


### PR DESCRIPTION
The Facebook Messenger API requires a valid (not self-signed) SSL certificate to work with the webhook. This adds the code to support it. However, additional instructions may be needed in the "Get Started" tutorial as to how to get a valid certificate.

Also adds the additional parameters to node/config/default.json to set the locations of the required files