### PR TITLE
Accept node versions greater than 10. Update date.

### DIFF
--- a/quick-start/CHANGELOG.md
+++ b/quick-start/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.0] - 2021-01-26
+
+### Changed
+
+- Upgraded [Node](https://github.com/nodejs/node) to version greater than 10.x
+- Date to 2021
+
 ## [2.0.0] - 2019-02-01
 
 ### Added

--- a/quick-start/app.js
+++ b/quick-start/app.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-present, Facebook, Inc. All rights reserved.
+ * Copyright 2021-present, Facebook, Inc. All rights reserved.
  *
  * This source code is licensed under the license found in the
  * LICENSE file in the root directory of this source tree.

--- a/quick-start/package.json
+++ b/quick-start/package.json
@@ -13,7 +13,7 @@
     "request": "^2.88.0"
   },
   "engines": {
-    "node": "10.x"
+    "node": ">=10.x"
   },
   "repository": {
     "url": "https://github.com/fbsamples/messenger-platform-samples"


### PR DESCRIPTION
Updating this PR to accept *any* node versions 10 or above, and to reflect it's now 2021. :)